### PR TITLE
Feature/home 신한투자증권 OpenAPI 마켓이슈 데이터를 받아와서 테이블 형식으로 보이도록 기능 구현

### DIFF
--- a/src/apis/marketIssuesApi.ts
+++ b/src/apis/marketIssuesApi.ts
@@ -1,0 +1,5 @@
+import axios from "axios";
+
+export const fetchMarketIssuesApi = () => {
+  return axios.get("http://52.78.236.23:3000/shinhan/market-issue");
+};

--- a/src/components/HomeMarketIssues.tsx
+++ b/src/components/HomeMarketIssues.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from "react";
+import { fetchMarketIssuesApi } from "../apis/marketIssuesApi"; // 수정된 경로
+
+interface ListItem {
+  bbsName: string;
+  title: string;
+  regDate: string;
+  messageId: string;
+  attachmentUrl: string;
+}
+
+interface ApiResponse {
+  dataHeader: {
+    successCode: string;
+    resultCode: string;
+    resultMessage: string;
+    category: string;
+  };
+  dataBody: {
+    list: ListItem[];
+  };
+}
+
+const MarketIssues: React.FC = () => {
+  const [data, setData] = useState<ListItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchMarketIssuesApi()
+      .then((response) => {
+        const responseData = response.data as ApiResponse;
+        console.log(responseData);
+        setData(responseData.dataBody.list.slice(0, 4));
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error("Error fetching data:", error);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        console.log(error.response);
+        setError("Error fetching data");
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+
+  return (
+    <div className="relative overflow-x-auto shadow-md sm:rounded-lg">
+      <table className="w-full text-left text-sm text-gray-500 rtl:text-right dark:text-gray-400">
+        <thead className="bg-gray-50 text-xs uppercase text-gray-700 dark:bg-gray-700 dark:text-gray-400">
+          <tr>
+            <th scope="col" className="px-6 py-3">
+              Title
+            </th>
+            <th scope="col" className="px-6 py-3">
+              Date
+            </th>
+            <th scope="col" className="px-6 py-3">
+              <span className="sr-only">Download</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((item, index) => (
+            <tr
+              key={index}
+              className="border-b bg-white hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-600"
+            >
+              <th
+                scope="row"
+                className="whitespace-nowrap px-6 py-4 font-medium text-gray-900 dark:text-white"
+              >
+                {item.title}
+              </th>
+              <td className="px-6 py-4">{item.regDate}</td>
+              <td className="px-6 py-4 text-right">
+                <a
+                  href={item.attachmentUrl}
+                  className="font-medium text-blue-600 hover:underline dark:text-blue-500"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Download
+                </a>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default MarketIssues;

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import Profile from "~/components/HomeProfile";
 import WeeklyCalendar from "~/components/WeeklyCalender";
 import Card from "~/components/HomeCard";
+import MarketIssues from "~/components/HomeMarketIssues";
 
 const Home: NextPage = () => {
   const [isHydrated, setIsHydrated] = useState(false);
@@ -33,7 +34,8 @@ const Home: NextPage = () => {
           <div className="pt-[40px]"></div>
           <div className="flex flex-row justify-evenly">
             <Card title="시장 지표" content="시장 지표 api 연결" />
-            <Card title="최신 금융 칼럼" content="금융 칼럼 api 연결" />
+            {/* <Card title="최신 금융 칼럼" content="금융 칼럼 api 연결" /> */}
+            <MarketIssues />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 변경사항
<img width="600" alt="image" src="https://github.com/PDA-JUTOPIA/JUTOPIA-FRONT/assets/164445937/23fd559f-3dff-4fe9-a981-3d002783037f">

## 주의사항
- api 파일 내 요청하는 배포된 서버 ip 기준으로 설정되어 있음 -> 로컬 서버에서 확인하고 싶을 시 127.0.0.1로 변경 필요
- 파일 위치 : src/apis/marketIssuesApi.ts  
<img width="300" alt="image" src="https://github.com/PDA-JUTOPIA/JUTOPIA-FRONT/assets/164445937/ecafdda0-3141-4abf-85df-2f6afce819b0">
