### PR TITLE
feat: 모바일뷰 topbar, bottom bar 수정

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -22,54 +22,55 @@ const TopBar = (props: TopBarProps) => {
   };
 
   return (
-    <div className="bg-gray fixed left-0 right-0 top-0 flex h-16 items-center justify-between border-b-2 border-gray-200 px-5 text-xl font-bold text-gray-300 md:hidden">
-      <div style={{ display: "hidden" }}>
-        <MoreOptionsSvg />
-      </div>
-
-      <span className="text-gray-400">{props.menuName}</span>
-      <MoreOptionsSvg
-        onClick={() => setMenu((x) => (x === "MORE" ? "HIDDEN" : "MORE"))}
-        role="button"
-        tabIndex={0}
-        aria-label="Toggle more menu"
-        fillColor="darkgray"
-      />
-      <div
-        className={[
-          "absolute left-0 right-0 top-full bg-white transition duration-300",
-          menu === "HIDDEN" ? "opacity-0" : "opacity-100",
-        ].join(" ")}
-        aria-hidden={menu === "HIDDEN"}
-      >
+    <div className="md:hidden">
+      {" "}
+      {/* This class ensures the TopBar is only visible on mobile */}
+      <div className="fixed left-0 right-0 top-0 z-50 flex h-16 items-center justify-between border-b-2 border-gray-200 bg-white px-5 text-xl font-bold text-gray-300">
+        <div className="invisible">
+          <MoreOptionsSvg />
+        </div>
+        <span className="text-gray-700">{props.menuName}</span>
+        <MoreOptionsSvg
+          onClick={() => setMenu((x) => (x === "MORE" ? "HIDDEN" : "MORE"))}
+          role="button"
+          tabIndex={0}
+          aria-label="Toggle more menu"
+          fillColor="darkgray"
+        />
         {menu === "MORE" && (
-          <div className="flex grow flex-col">
-            <div
-              className="flex items-center gap-2 p-2 font-bold text-gray-700"
-              style={{
-                fontFamily: "TTLaundryGothicB",
-                cursor: "pointer",
-                borderTop: "1px solid gray",
-                borderBottom: "1px solid gray",
-              }}
-              onClick={handleLogOut}
-            >
-              <LogoutIconSvg className="h-10 w-10" />
-              <span style={{ fontSize: "16px" }}>로그아웃</span>
+          <div
+            className="absolute left-0 right-0 top-full z-40 bg-white opacity-100 transition duration-300"
+            aria-hidden={menu === "HIDDEN"}
+          >
+            <div className="flex grow flex-col">
+              <div
+                className="flex items-center gap-2 p-2 font-bold text-gray-700"
+                style={{
+                  fontFamily: "TTLaundryGothicB",
+                  cursor: "pointer",
+                  borderTop: "1px solid gray",
+                  borderBottom: "1px solid gray",
+                }}
+                onClick={handleLogOut}
+              >
+                <LogoutIconSvg className="h-10 w-10" />
+                <span style={{ fontSize: "16px" }}>로그아웃</span>
+              </div>
+              {props.additionalContent}
             </div>
-            {props.additionalContent}
           </div>
         )}
+      </div>
+      {menu === "MORE" && (
         <div
-          className={[
-            "absolute left-0 top-full h-screen w-screen bg-black opacity-30",
-            menu === "HIDDEN" ? "pointer-events-none" : "",
-          ].join(" ")}
+          className="fixed left-0 top-16 z-30 h-screen w-screen bg-black opacity-30"
           onClick={() => setMenu("HIDDEN")}
           aria-label="Hide menu"
           role="button"
         />
-      </div>
+      )}
+      <div className="h-16"></div>{" "}
+      {/* To prevent content from being hidden behind the TopBar */}
     </div>
   );
 };

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -1,12 +1,19 @@
 import type { NextPage } from "next";
 import { BottomBar } from "~/components/BottomBar";
 import { LeftBar } from "~/components/LeftBar";
-import { EditPencilSvg, ProfileTimeJoinedSvg } from "~/components/Svgs";
+import {
+  EditPencilSvg,
+  ProfileTimeJoinedSvg,
+  MoreOptionsSvg,
+  CheckSvg,
+  LogoutIconSvg,
+} from "~/components/Svgs";
 import { useBoundStore } from "~/hooks/useBoundStore";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import dayjs from "dayjs";
 import ChallengeGrid from "~/components/ChallengeGrid";
+import TopBar from "~/components/TopBar";
 
 const MyPage: NextPage = () => {
   const [updateState, setUpdateState] = useState<"update" | "view">("view");
@@ -44,6 +51,11 @@ const MyPage: NextPage = () => {
 
   return (
     <div className="font-ttlaundrygothicb">
+      <MyPageTopBar
+        updateState={updateState}
+        setUpdateState={setUpdateState}
+        updateProfile={updateProfile}
+      />
       <LeftBar selectedTab="마이페이지" />
       <div className="flex justify-center gap-3 pt-14 md:ml-[8rem] lg:ml-64 lg:gap-12">
         <div className="flex w-full max-w-4xl flex-col gap-5 p-5">
@@ -69,6 +81,12 @@ const MyPage: NextPage = () => {
 
 export default MyPage;
 
+type MyPageTopBarProps = {
+  updateState: "update" | "view";
+  setUpdateState: (state: "update" | "view") => void;
+  updateProfile: () => void;
+};
+
 type MypageTopSectionProps = {
   updateState: "update" | "view";
   name: string;
@@ -81,6 +99,84 @@ type MypageTopSectionProps = {
   updateProfile: () => void;
 };
 
+const MyPageTopBar = (props: MyPageTopBarProps) => {
+  type MenuState = "HIDDEN" | "MORE";
+  const [menu, setMenu] = useState<MenuState>("HIDDEN");
+
+  const logOut = useBoundStore((x) => x.logOut);
+  var router = useRouter();
+
+  const handleLogOut = () => {
+    void logOut();
+    void router.push("/");
+  };
+
+  return (
+    <div className="fixed left-0 right-0 top-0 flex h-16 items-center justify-between border-b-2 border-gray-200 bg-white px-5 text-xl font-bold text-gray-300 md:hidden">
+      <MoreOptionsSvg
+        onClick={() => setMenu((x) => (x === "MORE" ? "HIDDEN" : "MORE"))}
+        role="button"
+        tabIndex={0}
+        aria-label="Toggle more menu"
+        fillColor="darkgray"
+      />
+      <div
+        className={[
+          "absolute left-0 right-0 top-full bg-white transition duration-300",
+          menu === "HIDDEN" ? "opacity-0" : "opacity-100",
+        ].join(" ")}
+        aria-hidden={menu === "HIDDEN"}
+      >
+        {((): null | JSX.Element => {
+          switch (menu) {
+            case "MORE":
+              return (
+                <div className="flex grow flex-col">
+                  <div
+                    className="flex items-center gap-2 p-2 font-bold text-gray-700"
+                    style={{
+                      fontFamily: "TTLaundryGothicB",
+                      cursor: "pointer",
+                      borderTop: "1px solid gray",
+                      borderBottom: "1px solid gray",
+                    }}
+                    onClick={handleLogOut}
+                  >
+                    <LogoutIconSvg className="h-10 w-10" />
+                    <span style={{ fontSize: "16px" }}>로그아웃</span>
+                  </div>
+                </div>
+              );
+            case "HIDDEN":
+              return null;
+          }
+        })()}
+        <div
+          className={[
+            "absolute left-0 top-full h-screen w-screen bg-black opacity-30",
+            menu === "HIDDEN" ? "pointer-events-none" : "",
+          ].join(" ")}
+          onClick={() => setMenu("HIDDEN")}
+          aria-label="Hide menu"
+          role="button"
+        />
+      </div>
+      <span className="text-gray-400">😎마이 페이지😎</span>
+      {props.updateState === "view" ? (
+        <div
+          onClick={() => props.setUpdateState("update")}
+          style={{ cursor: "pointer" }}
+        >
+          <EditPencilSvg iconColor="darkgray" />
+        </div>
+      ) : (
+        <div onClick={props.updateProfile} style={{ cursor: "pointer" }}>
+          <CheckSvg />
+        </div>
+      )}
+    </div>
+  );
+};
 const MypageTopSection = (props: MypageTopSectionProps) => {
   const router = useRouter();
   const loggedIn = useBoundStore((x) => x.loggedIn);

--- a/src/pages/reward.tsx
+++ b/src/pages/reward.tsx
@@ -1,4 +1,5 @@
 import type { NextPage } from "next";
+import TopBar from "~/components/TopBar";
 import { LeftBar } from "~/components/LeftBar";
 import { BottomBar } from "~/components/BottomBar";
 import { useState, useEffect } from "react";
@@ -17,10 +18,11 @@ const Reward: NextPage = () => {
   }
   return (
     <div className="font-ttlaundrygothicb">
+      <TopBar menuName="도전과제" />
       <LeftBar selectedTab="리워드" />
 
-      <div className="flex justify-center gap-3 pt-14 sm:p-6 sm:pt-10 md:ml-24 lg:ml-64 lg:gap-12">
-        <div className="flex max-w-[65rem] grow flex-col">
+      <div className="flex justify-center gap-3 pt-14 md:ml-[8rem] lg:ml-64 lg:gap-12">
+        <div className="flex w-full max-w-4xl flex-col gap-5 p-5">
           <h1 className="border-b-2 pb-4 text-center text-4xl font-bold">
             {" "}
             🔥도전과제🔥 <div className="pt-[40px]"></div>
@@ -29,7 +31,7 @@ const Reward: NextPage = () => {
           <ChallengeGrid />
         </div>
       </div>
-
+      <div className="pt-[90px]"></div>
       <BottomBar selectedTab="리워드" />
     </div>
   );


### PR DESCRIPTION
## 주요 변경 사항

- 기존 top bar 하얀색 배경으로 고정 -> 로그아웃 가능
![image](https://github.com/PDA-JUTOPIA/JUTOPIA-FRONT/assets/83602306/2cd640f5-1f8b-4daa-80f5-cd232de4a86b)

- 마이페이지 tob bar edit 및 로그아웃 가능
- bottom bar가 요소를 가리는 현상 수정
![image](https://github.com/PDA-JUTOPIA/JUTOPIA-FRONT/assets/83602306/8e596214-e26f-4df6-9124-24c0fbfa50ba)

