### PR TITLE
Feature/home

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.11.5",
         "@mui/material": "^5.15.20",
         "@t3-oss/env-nextjs": "^0.7.3",
+        "@tippyjs/react": "^4.2.6",
         "aos": "^2.3.4",
         "axios": "^1.7.2",
         "dayjs": "^1.11.10",
@@ -26,6 +27,7 @@
         "react-transition-group": "^4.4.5",
         "react-zoom-pan-pinch": "^3.4.4",
         "styled-components": "^6.1.11",
+        "tippy.js": "^6.3.7",
         "zod": "^3.22.4",
         "zustand": "^4.4.7"
       },
@@ -1299,6 +1301,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tippyjs/react": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz",
+      "integrity": "sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==",
+      "dependencies": {
+        "tippy.js": "^6.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@types/eslint": {
@@ -6515,6 +6529,14 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
       }
     },
     "node_modules/to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.11.5",
     "@mui/material": "^5.15.20",
     "@t3-oss/env-nextjs": "^0.7.3",
+    "@tippyjs/react": "^4.2.6",
     "aos": "^2.3.4",
     "axios": "^1.7.2",
     "dayjs": "^1.11.10",
@@ -27,6 +28,7 @@
     "react-transition-group": "^4.4.5",
     "react-zoom-pan-pinch": "^3.4.4",
     "styled-components": "^6.1.11",
+    "tippy.js": "^6.3.7",
     "zod": "^3.22.4",
     "zustand": "^4.4.7"
   },

--- a/src/components/HomeMarketIssues.tsx
+++ b/src/components/HomeMarketIssues.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import { fetchMarketIssuesApi } from "../apis/marketIssuesApi";
 import { Modal, ModalBackdrop } from "./styled";
 import he from "he";
+import Tippy from "@tippyjs/react";
+import "tippy.js/dist/tippy.css";
 
 interface ListItem {
   id: number;
@@ -69,9 +71,13 @@ const MarketIssues: React.FC = () => {
                 제목
               </th>
               <th scope="col" className="hidden px-4 py-3 md:table-cell">
+                {" "}
+                {/* 모바일에서 숨기기 */}
                 발행일
               </th>
               <th scope="col" className="hidden px-4 py-3 md:table-cell">
+                {" "}
+                {/* 모바일에서 숨기기 */}
                 PDF 파일
                 <span className="sr-only">Download</span>
               </th>
@@ -88,12 +94,11 @@ const MarketIssues: React.FC = () => {
                   className="whitespace-nowrap px-4 py-2 font-medium text-gray-900 dark:text-white"
                 >
                   <div className="flex items-center justify-between">
-                    <span
-                      className="mr-2 w-40 truncate md:w-auto"
-                      title={item.title}
-                    >
-                      {item.title}
-                    </span>
+                    <Tippy content={item.title}>
+                      <span className="mr-2 w-40 truncate md:w-auto">
+                        {item.title}
+                      </span>
+                    </Tippy>
                     <button
                       type="button"
                       className="rounded-full border border-gray-300 bg-white px-3 py-1.5 text-xs font-bold text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
@@ -105,8 +110,11 @@ const MarketIssues: React.FC = () => {
                 </th>
                 <td className="hidden px-4 py-2 md:table-cell">
                   {item.reg_date}
-                </td>
+                </td>{" "}
+                {/* 모바일에서 숨기기 */}
                 <td className="hidden px-4 py-2 text-right md:table-cell">
+                  {" "}
+                  {/* 모바일에서 숨기기 */}
                   <a
                     href={item.attachment_url}
                     className="font-medium text-blue-600 hover:underline dark:text-blue-500"

--- a/src/components/HomeMarketIssues.tsx
+++ b/src/components/HomeMarketIssues.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { fetchMarketIssuesApi } from "../apis/marketIssuesApi";
 import { Modal, ModalBackdrop } from "./styled";
-import he from "he";
 import Tippy from "@tippyjs/react";
 import "tippy.js/dist/tippy.css";
 
@@ -17,6 +16,10 @@ interface ListItem {
   updatedAt: string;
 }
 
+function truncate(str: string, maxlength: number): string {
+  return str.length > maxlength ? str.slice(0, maxlength - 1) + "…" : str;
+}
+
 const MarketIssues: React.FC = () => {
   const [data, setData] = useState<ListItem[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
@@ -24,6 +27,7 @@ const MarketIssues: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<ListItem | null>(null);
   const [visibleItems, setVisibleItems] = useState<number>(10);
+  const tableRef = useRef<HTMLDivElement>(null);
 
   const toggleModal = () => {
     setIsModalOpen(!isModalOpen);
@@ -62,22 +66,27 @@ const MarketIssues: React.FC = () => {
   }
 
   return (
-    <div className="relative overflow-x-auto shadow-md sm:rounded-lg">
+    <div
+      ref={tableRef}
+      className="relative overflow-x-auto shadow-md sm:rounded-lg"
+    >
       <div className="max-h-60 overflow-y-auto">
         <table className="w-full text-left text-sm text-gray-500 rtl:text-right dark:text-gray-400">
           <thead className="bg-gray-50 text-xs uppercase text-gray-700 dark:bg-gray-700 dark:text-gray-400">
             <tr>
-              <th scope="col" className="px-4 py-3">
+              <th scope="col" className="truncate px-4 py-3">
                 제목
               </th>
-              <th scope="col" className="hidden px-4 py-3 md:table-cell">
-                {" "}
-                {/* 모바일에서 숨기기 */}
+              <th
+                scope="col"
+                className="hidden table-fixed px-4 py-3 md:table-cell"
+              >
                 발행일
               </th>
-              <th scope="col" className="hidden px-4 py-3 md:table-cell">
-                {" "}
-                {/* 모바일에서 숨기기 */}
+              <th
+                scope="col"
+                className="hidden table-fixed px-4 py-3 md:table-cell"
+              >
                 PDF 파일
                 <span className="sr-only">Download</span>
               </th>
@@ -94,9 +103,23 @@ const MarketIssues: React.FC = () => {
                   className="whitespace-nowrap px-4 py-2 font-medium text-gray-900 dark:text-white"
                 >
                   <div className="flex items-center justify-between">
-                    <Tippy content={item.title}>
+                    <Tippy
+                      className="overflow-hidden"
+                      content={item.title}
+                      appendTo={tableRef.current}
+                      popperOptions={{
+                        modifiers: [
+                          {
+                            name: "preventOverflow",
+                            options: {
+                              boundary: tableRef.current,
+                            },
+                          },
+                        ],
+                      }}
+                    >
                       <span className="mr-2 w-40 truncate md:w-auto">
-                        {item.title}
+                        {truncate(item.title, 40)}
                       </span>
                     </Tippy>
                     <button
@@ -161,7 +184,13 @@ const MarketIssues: React.FC = () => {
                     </p>
                     <hr className="mb-3 mt-3" />
                     <p>
-                      <strong>내용:</strong> {he.decode(selectedItem.content)}{" "}
+                      <strong>내용:</strong>
+                      {/* {he.decode(selectedItem.content)} */}
+                      <div
+                        dangerouslySetInnerHTML={{
+                          __html: selectedItem.content,
+                        }}
+                      ></div>
                     </p>
                   </div>
                 </div>

--- a/src/components/HomeMarketIssues.tsx
+++ b/src/components/HomeMarketIssues.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { fetchMarketIssuesApi } from "../apis/marketIssuesApi";
 import { Modal, ModalBackdrop } from "./styled";
-import he from "he"; // he 라이브러리 import
+import he from "he";
 
 interface ListItem {
   id: number;
@@ -21,7 +21,7 @@ const MarketIssues: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<ListItem | null>(null);
-  const [visibleItems, setVisibleItems] = useState<number>(10); // 초기값을 10으로 설정
+  const [visibleItems, setVisibleItems] = useState<number>(10);
 
   const toggleModal = () => {
     setIsModalOpen(!isModalOpen);
@@ -62,20 +62,16 @@ const MarketIssues: React.FC = () => {
   return (
     <div className="relative overflow-x-auto shadow-md sm:rounded-lg">
       <div className="max-h-60 overflow-y-auto">
-        {" "}
-        {/* Y축 스크롤 추가 */}
         <table className="w-full text-left text-sm text-gray-500 rtl:text-right dark:text-gray-400">
           <thead className="bg-gray-50 text-xs uppercase text-gray-700 dark:bg-gray-700 dark:text-gray-400">
-            {" "}
-            {/* sticky 클래스 추가로 제목 행 고정 */}
             <tr>
               <th scope="col" className="px-4 py-3">
                 제목
               </th>
-              <th scope="col" className="px-4 py-3">
+              <th scope="col" className="hidden px-4 py-3 md:table-cell">
                 발행일
               </th>
-              <th scope="col" className="px-4 py-3">
+              <th scope="col" className="hidden px-4 py-3 md:table-cell">
                 PDF 파일
                 <span className="sr-only">Download</span>
               </th>
@@ -91,9 +87,13 @@ const MarketIssues: React.FC = () => {
                   scope="row"
                   className="whitespace-nowrap px-4 py-2 font-medium text-gray-900 dark:text-white"
                 >
-                  {/* 제목과 버튼을 감싸는 flex 컨테이너 추가 */}
                   <div className="flex items-center justify-between">
-                    <span className="mr-2">{item.title}</span>
+                    <span
+                      className="mr-2 w-40 truncate md:w-auto"
+                      title={item.title}
+                    >
+                      {item.title}
+                    </span>
                     <button
                       type="button"
                       className="rounded-full border border-gray-300 bg-white px-3 py-1.5 text-xs font-bold text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
@@ -103,8 +103,10 @@ const MarketIssues: React.FC = () => {
                     </button>
                   </div>
                 </th>
-                <td className="px-4 py-2">{item.reg_date}</td>
-                <td className="px-4 py-2 text-right">
+                <td className="hidden px-4 py-2 md:table-cell">
+                  {item.reg_date}
+                </td>
+                <td className="hidden px-4 py-2 text-right md:table-cell">
                   <a
                     href={item.attachment_url}
                     className="font-medium text-blue-600 hover:underline dark:text-blue-500"
@@ -118,7 +120,7 @@ const MarketIssues: React.FC = () => {
             ))}
           </tbody>
         </table>
-        {visibleItems < data.length && ( // 더보기 버튼 표시 조건
+        {visibleItems < data.length && (
           <div className="mb-2 mt-2 flex justify-center">
             <button
               onClick={loadMoreItems}


### PR DESCRIPTION
# 변경사항
- [테이블 모바일 화면에서 컬럼 2개 hidden처리 및 제목이 길 경우 축약되어 보이도록 css 구현](https://github.com/PDA-JUTOPIA/JUTOPIA-FRONT/commit/bcf54c1436aa1aa07af960b8847ac5d9802d4c67)
- [툴팁 적용 완료](https://github.com/PDA-JUTOPIA/JUTOPIA-FRONT/commit/148ab8f82aeddfe922b9b155b2c9d3c74a05ef7c)
---------------------------
- PC
<img width="500" alt="image" src="https://github.com/PDA-JUTOPIA/JUTOPIA-FRONT/assets/164445937/0bc7059f-5ff9-4291-8659-828dc8135738">

- 모바일
<img width="270" alt="image" src="https://github.com/PDA-JUTOPIA/JUTOPIA-FRONT/assets/164445937/a9173fde-d755-49f6-8bd7-74afa48aeb60">
